### PR TITLE
Updated README.md to clarify "GCP Set-Up" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ pip install -r .\requirements.txt
 
 In order to properly leverage the GCP's features, the user must verify that their GCP admin has granted the user's GCP Client both Storage and Pub/Sub Admin privileges. Additionally, it may be helpful to grant these privileges on a user account-basis.
 
-The user must also retrieve the JSON credentials for the service account used from their GCP administrator. The path to this JSON file will be assigned to the "GOOGLE_APPLICATION_CREDENTIALS" environment variable, as shown in the def main() function of the data_manager/source_code/main.py script.
+If the user runs the script on a local machine, they must also retrieve the JSON credentials for the service account used from their GCP administrator. The path to this JSON file will be assigned to the "GOOGLE_APPLICATION_CREDENTIALS" environment variable, as shown in the def main() function of the data_manager/source_code/main.py script.
+
+If the user refactors the script to leverage Google Cloud Functions, including these credentials in the script itself are likely not necessary.
 
 ## How to Run
 


### PR DESCRIPTION
Updated w this clarification on the JSON creds: The JSON credentials assigned to the GOOGLE_APPLICATION_CREDENTIALS are only necessary if run on a local machine. If run as a Google Cloud Function, no need for these creds (and in fact it may throw an error).